### PR TITLE
"ors sync --all" functionality

### DIFF
--- a/lib/ors/commands/help.rb
+++ b/lib/ors/commands/help.rb
@@ -9,7 +9,7 @@ Usage: ./ors <action> [environment=production] [options]
 === Actions
 changes       View changes between what is deployed and committed
 check         Prints out contents of restart.timestamp on the app servers
-console       Bring up a console on the production servers
+console       Bring up a console on the console server
 deploy        Update the code, run the migrations, and restart unicorn
 help          You're looking at it
 logs          Show the last few log entries from the production servers

--- a/lib/ors/commands/help.rb
+++ b/lib/ors/commands/help.rb
@@ -15,6 +15,7 @@ help          You're looking at it
 logs          Show the last few log entries from the production servers
 migrate       Runs the migrations on the migration server
 restart       Retarts unicorn on the app servers
+runner        Runs ruby code via Rails' runner on the console server
 setup         Sets up the default environment on the servers
 start         Starts up unicorn on the app servers
 stop          Stops unicorn on the app servers

--- a/lib/ors/commands/runner.rb
+++ b/lib/ors/commands/runner.rb
@@ -1,0 +1,35 @@
+module ORS::Commands
+  class Runner < Base
+    def execute
+      begin
+        code = ORS::Config.options[ ORS::Config.options.index{|e| e =~ /^(-c|--code)$/} + 1 ]
+        raise if code.blank?
+      rescue
+        fatal "ERROR: Missing option --code 'ruby code'."
+      end
+      results = execute_command console_server,
+                      %(source ~/.rvm/scripts/rvm),
+                      %({ cd #{deploy_directory} > /dev/null; }), # Silence RVM's "Using... gemset..."
+                      %(if [ -f script/rails ]; then bundle exec rails runner -e #{environment} \\"#{code}\\"; else ./script/runner -e #{environment} \\"#{code}\\"; fi),
+                      :capture => true, :quiet_ssh => true
+      results.sub!(/\AUsing BufferedLogger due to exception: .*?\n/, '') # The central_logger gem spits this out without any way of shutting it up
+      puts results
+    end
+
+    def help
+      puts <<-END
+Usage: ./ors runner [environment=production] --code "ruby code here" [options]
+
+=== Description
+Runs rails runner returning the result on STDOUT.
+The ruby code will be transmitted within several nested quotes:  '"\"ruby code here\""'
+Keep that in mind if you need to use quotes.
+
+=== Options
+--code       (or -c)   The code to run.
+--pretend    (or -p)   Don't execute anything, just show me what you're going to do
+--no-gateway (or -ng)  Don't use a gateway (if you're inside the firewall)
+      END
+    end
+  end
+end

--- a/lib/ors/commands/runner.rb
+++ b/lib/ors/commands/runner.rb
@@ -3,7 +3,7 @@ module ORS::Commands
     def execute
       begin
         code = ORS::Config.options[ ORS::Config.options.index{|e| e =~ /^(-c|--code)$/} + 1 ]
-        raise if code.blank?
+        raise if code.strip.empty?
       rescue
         fatal "ERROR: Missing option --code 'ruby code'."
       end

--- a/lib/ors/commands/sync.rb
+++ b/lib/ors/commands/sync.rb
@@ -3,7 +3,18 @@ module ORS::Commands
   class Sync < Base
 
     def execute
-      system "git co master && git co #{environment} && git pull && git merge master && git push && git co master"
+      if options.first == '--all'
+        environments = ORS::Config.valid_environments
+      else
+        environments = [environment]
+      end
+
+      environments.each do |e|
+        unless ORS::Config.git.branches[e].nil?
+          info "Syncing environment/branch #{e}..."
+          system "git co master && git co #{e} && git pull && git merge master && git push && git co master"
+        end
+      end
     end
 
   end

--- a/lib/ors/commands/sync.rb
+++ b/lib/ors/commands/sync.rb
@@ -9,10 +9,15 @@ module ORS::Commands
         environments = [environment]
       end
 
-      environments.each do |e|
-        unless ORS::Config.git.branches[e].nil?
-          info "Syncing environment/branch #{e}..."
-          system "git co master && git co #{e} && git pull && git merge master && git push && git co master"
+      environments.each do |environment|
+        unless ORS::Config.git.branches[environment].nil?
+          info "Syncing environment/branch #{environment}..."
+          execute_command :localhost, %(git checkout master),
+                                      %(git checkout #{environment}),
+                                      %(git pull),
+                                      %(git rebase master),
+                                      %(git push),
+                                      %(git checkout master)
         end
       end
     end

--- a/lib/ors/config.rb
+++ b/lib/ors/config.rb
@@ -5,6 +5,7 @@ module ORS
 
     mattr_accessor :name, :environment, :use_gateway, :pretending, :log_lines, :rails2, :deploy_hook
     mattr_accessor :gateway, :deploy_user, :repo, :base_path, :web_servers, :app_servers, :migration_server, :console_server, :cron_server
+    mattr_accessor :options
 
     self.environment = "production"
     self.pretending = false
@@ -16,6 +17,7 @@ module ORS
       def parse_options options
         self.name = name_from_git
         self.environment = options.shift unless options.empty? or options.first.match(/^-/)
+        self.options = options.dup
 
         options.each do |option|
           case option

--- a/lib/ors/helpers.rb
+++ b/lib/ors/helpers.rb
@@ -83,6 +83,7 @@ module ORS
     def execute_command server, *command_array
       options = {:exec => false, :capture => false}
       options.merge!(command_array.pop) if command_array.last.is_a?(Hash)
+      options[:local] = true if server.to_s == "localhost"
 
       command = build_command(server, command_array, options)
 
@@ -118,10 +119,14 @@ module ORS
       commands = command_array.join " && "
       psuedo_tty = options[:exec] ? '-t ' : ''
 
-      if use_gateway
-        %(ssh #{psuedo_tty}#{gateway} 'ssh #{psuedo_tty}#{deploy_user}@#{server} "#{commands}"')
+      if options[:local]
+        commands
       else
-        %(ssh #{psuedo_tty}#{deploy_user}@#{server} "#{commands}")
+        if use_gateway
+          %(ssh #{psuedo_tty}#{gateway} 'ssh #{psuedo_tty}#{deploy_user}@#{server} "#{commands}"')
+        else
+          %(ssh #{psuedo_tty}#{deploy_user}@#{server} "#{commands}")
+        end
       end
     end
 

--- a/lib/ors/helpers.rb
+++ b/lib/ors/helpers.rb
@@ -79,9 +79,9 @@ module ORS
       end.map {|thread| thread.join }
     end
 
-    # options = {:exec => ?, :capture => ?}
+    # options = {:exec => ?, :capture => ?, :quiet_ssh => ?}
     def execute_command server, *command_array
-      options = {:exec => false, :capture => false}
+      options = {:exec => false, :capture => false, :quiet_ssh => false}
       options.merge!(command_array.pop) if command_array.last.is_a?(Hash)
       options[:local] = true if server.to_s == "localhost"
 
@@ -118,14 +118,15 @@ module ORS
 
       commands = command_array.join " && "
       psuedo_tty = options[:exec] ? '-t ' : ''
+      quiet_ssh = options[:quiet_ssh] ? '-q ' : ''
 
       if options[:local]
         commands
       else
         if use_gateway
-          %(ssh #{psuedo_tty}#{gateway} 'ssh #{psuedo_tty}#{deploy_user}@#{server} "#{commands}"')
+          %(ssh #{quiet_ssh}#{psuedo_tty}#{gateway} 'ssh #{quiet_ssh}#{psuedo_tty}#{deploy_user}@#{server} "#{commands}"')
         else
-          %(ssh #{psuedo_tty}#{deploy_user}@#{server} "#{commands}")
+          %(ssh #{quiet_ssh}#{psuedo_tty}#{deploy_user}@#{server} "#{commands}")
         end
       end
     end

--- a/lib/ors/version.rb
+++ b/lib/ors/version.rb
@@ -1,3 +1,3 @@
 module ORS
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/lib/ors/version.rb
+++ b/lib/ors/version.rb
@@ -1,3 +1,3 @@
 module ORS
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/ors/version.rb
+++ b/lib/ors/version.rb
@@ -1,3 +1,3 @@
 module ORS
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/ors/commands/runner_spec.rb
+++ b/spec/ors/commands/runner_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe ORS::Commands::Runner do
+
+  context "#run" do
+    before do
+      stub(subject).name {'abc/growhealthy'}
+      stub(subject).environment {'production'}
+    end
+
+    it "should require --code 'ruby code'" do
+      lambda {subject.execute}.should raise_error
+    end
+
+    it "should require an argument to --code" do
+      ORS::Config.parse_options %w(--code)
+      lambda {subject.execute}.should raise_error
+    end
+
+    it "should require an argument to -c" do
+      ORS::Config.parse_options %w(--c)
+      lambda {subject.execute}.should raise_error
+    end
+
+    it "should be successful with an argument to --code" do
+      ORS::Config.parse_options %w(--code true)
+      mock(subject).execute_command(is_a(String), is_a(String), is_a(String), is_a(String), is_a(Hash)).returns("results")
+      lambda {subject.execute}.should_not raise_error
+    end
+
+    it "should be successful with an argument to -c" do
+      ORS::Config.parse_options %w(-c true)
+      mock(subject).execute_command(is_a(String), is_a(String), is_a(String), is_a(String), is_a(Hash)).returns("results")
+      lambda {subject.execute}.should_not raise_error
+    end
+  end
+end

--- a/spec/ors/commands/runner_spec.rb
+++ b/spec/ors/commands/runner_spec.rb
@@ -22,6 +22,11 @@ describe ORS::Commands::Runner do
       lambda {subject.execute}.should raise_error
     end
 
+    it "should require a non-empty argument to --code" do
+      ORS::Config.parse_options ['--code', ' ']
+      lambda {subject.execute}.should raise_error
+    end
+
     it "should be successful with an argument to --code" do
       ORS::Config.parse_options %w(--code true)
       mock(subject).execute_command(is_a(String), is_a(String), is_a(String), is_a(String), is_a(Hash)).returns("results")

--- a/spec/ors/helpers_spec.rb
+++ b/spec/ors/helpers_spec.rb
@@ -52,6 +52,10 @@ describe ORS::Helpers do
       it "should build the command with psuedo tty" do
         subject.build_command("server", %(cd /tmp), :exec => true).should == %(ssh -t deploy-gateway 'ssh -t deployer@server "cd /tmp"')
       end
+
+      it "should build the command with quiet mode" do
+        subject.build_command("server", %(cd /tmp), :quiet_ssh => true).should == %(ssh -q deploy-gateway 'ssh -q deployer@server "cd /tmp"')
+      end
     end
 
     context "without gateway" do
@@ -63,6 +67,10 @@ describe ORS::Helpers do
 
       it "should build the command with psuedo tty" do
         subject.build_command("server", %(cd /tmp), :exec => true).should == %(ssh -t deployer@server "cd /tmp")
+      end
+
+      it "should build the command with quiet mode" do
+        subject.build_command("server", %(cd /tmp), :quiet_ssh => true).should == %(ssh -q deployer@server "cd /tmp")
       end
     end
   end


### PR DESCRIPTION
store the CLI options so we can access them from individual commands.  tweak 'sync' to support --all to sync all valid environments at once
